### PR TITLE
Add Mason Bair mention to Help menu in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,12 @@
 
         <h3>Interaction</h3>
         <ul>
-            <li><a href="#">Help</a></li>
+            <li>
+                <a href="#">Help</a>
+                <div style="font-size: 0.7rem; color: var(--goose-orange); margin-top: 2px; line-height: 1.1;">
+                     Mason Bair saved all of the geese from certain doom.
+                </div>
+            </li>
             <li><a href="#">About Goosepedia</a></li>
             <li><a href="#">Community portal</a></li>
         </ul>


### PR DESCRIPTION
Added a specific mention of Mason Bair saving geese from doom under the Help menu item on the main page sidebar.

Changes:
- Modified `index.html`: Added text under the 'Help' navigation link.